### PR TITLE
Allow overriding matched URL param format

### DIFF
--- a/crossing.js
+++ b/crossing.js
@@ -2,14 +2,18 @@
   'use strict';
   // Provides utilities to deal with website/app urls. Provides functionality
   // for deep-linking Ajax calls, and a url mapper to generate dynamic urls.
-  function crossing() {
+  function crossing(nameMatcher) {
     if (!(this instanceof crossing)) {
       throw new Error('Crossing can not be called without instatiation. Please use "new Crossing()" instead');
     }
     this._urls = {};
     this._compiled = {};
     this._lastHash = '';
-    this._nameMatcher = new RegExp('<([a-zA-Z0-9-_%]{1,})>', 'g');
+    if (nameMatcher) {
+      this._nameMatcher = nameMatcher;
+    } else {
+      this._nameMatcher = new RegExp('<([a-zA-Z0-9-_%]{1,})>', 'g');
+    }
 
     this._getArgs = function(urlName, path) {
       var args = {};
@@ -116,7 +120,6 @@
     var urlName;
     var kwargs;
     urlName = this._getName(path);
-    //console.log(url + ' => ' + urlName);
     if (urlName) {
       kwargs = this._getArgs(urlName, path);
       url['name'] = urlName;
@@ -132,4 +135,3 @@
     window.crossing = crossing;
   }
 })();
-

--- a/test/crossing.test.js
+++ b/test/crossing.test.js
@@ -115,4 +115,23 @@ describe("Crossing Tests", function() {
 
   });
 
+  describe("#override matched param format", function () {
+    var urls = new Crossing(new RegExp(':([a-zA-Z0-9-_%]{1,})', 'g'));
+    var reactRouterPaths = {
+      'discussion:detail': ':team_slug/:discussion_id/:slug/',
+      'search': 'search/'
+    };
+
+    it("can resolve urls with parameters", function () {
+      urls.load(reactRouterPaths);
+      expect(urls.resolve('loop/23/discussion-name/').name).to.equal('discussion:detail');
+      expect(Object.keys(urls.resolve('loop/23/discussion-name/').kwargs).length).to.equal(3);
+    });
+    it("can resolve urls without parameters", function () {
+      urls.load(reactRouterPaths);
+      expect(urls.resolve('search/').name).to.equal('search');
+      expect(Object.keys(urls.resolve('search/').kwargs).length).to.equal(0);
+    });
+  });
+
 });


### PR DESCRIPTION
Make crossing more flexible to use without assumptions of the param matching format. 
