### PR TITLE
Throw errors, not strings

### DIFF
--- a/crossing.js
+++ b/crossing.js
@@ -63,7 +63,7 @@
     for (var key in kwargs) {
       if (kwargs.hasOwnProperty(key)) {
         if (!path.match('<' + key +'>')) {
-          throw('Invalid parameter ('+ key +') for '+ name);
+          throw new Error('Invalid parameter ('+ key +') for '+ name);
         }
         path = path.replace('<' + key +'>', kwargs[key]);
       }
@@ -91,7 +91,7 @@
   crossing.prototype.get = function(name, kwargs) {
     var path = this._urls[name];
     if (!this._urls[name]) {
-      throw('URL not found: ' + name);
+      throw new Error('URL not found: ' + name);
     }
     var _path = path;
 
@@ -103,7 +103,7 @@
 
     var missingArgs = path.match(this._nameMatcher);
     if (missingArgs) {
-      throw('Missing arguments (' + missingArgs.join(", ") + ') for url ' + _path);
+      throw new Error('Missing arguments (' + missingArgs.join(", ") + ') for url ' + _path);
     }
 
     return path;

--- a/test/crossing.test.js
+++ b/test/crossing.test.js
@@ -61,7 +61,8 @@ describe("Crossing Tests", function() {
         var url = urls.get('discussion:detail', {'team': 'loop', 'discussion_id': '3', 'slug': 'discussion'});
         expect(url).to.not.be.ok;
       } catch (e) {
-        expect(e).to.equal('Invalid parameter (team) for discussion:detail');
+        expect(e).to.be.instanceOf(Error);
+        expect(e.message).to.equal('Invalid parameter (team) for discussion:detail');
       }
     });
     it("can not get urls with missing parameters", function () {
@@ -69,7 +70,8 @@ describe("Crossing Tests", function() {
         var url = urls.get('discussion:detail');
         expect(url).to.not.be.ok;
       } catch (e) {
-        expect(e).to.equal("Missing arguments (<team_slug>, <discussion_id>, <slug>) for url <team_slug>/<discussion_id>/<slug>/");
+        expect(e).to.be.instanceOf(Error);
+        expect(e.message).to.equal("Missing arguments (<team_slug>, <discussion_id>, <slug>) for url <team_slug>/<discussion_id>/<slug>/");
       }
     });
   });
@@ -94,7 +96,8 @@ describe("Crossing Tests", function() {
         var url = urls.get('discussion:detail', 'loop');
         expect(url).to.not.be.ok;
       } catch (e) {
-        expect(e).to.equal("Missing arguments (<discussion_id>, <slug>) for url <team_slug>/<discussion_id>/<slug>/");
+        expect(e).to.be.instanceOf(Error);
+        expect(e.message).to.equal("Missing arguments (<discussion_id>, <slug>) for url <team_slug>/<discussion_id>/<slug>/");
       }
     });
   });


### PR DESCRIPTION
Hi, I changed the code to throw instances of Error instead of string messages. It is useful for debugging, because errors carry stack traces.
