### PR TITLE
Reusable kwargs

### DIFF
--- a/crossing.js
+++ b/crossing.js
@@ -60,14 +60,23 @@
 
   crossing.prototype._getPathByKwargs = function(name, kwargs) {
     var path = this._urls[name];
-    for (var key in kwargs) {
-      if (kwargs.hasOwnProperty(key)) {
-        if (!path.match('<' + key +'>')) {
-          throw new Error('Invalid parameter ('+ key +') for '+ name);
+    var matcher = this._nameMatcher;
+
+    if (kwargs) {
+      var args = path.match(matcher);
+
+      for (var i = 0; i < args.length; i++) {
+        var match = args[i];
+        var arg = match.replace(matcher, '$1');
+
+        if (typeof kwargs[arg] === 'undefined') {
+          throw new Error('Missing parameter (' + arg + ') for ' + name);
         }
-        path = path.replace('<' + key +'>', kwargs[key]);
+
+        path = path.replace(match, kwargs[arg]);
       }
     }
+
     return path;
   };
 

--- a/test/crossing.test.js
+++ b/test/crossing.test.js
@@ -56,15 +56,6 @@ describe("Crossing Tests", function() {
     it("can get urls with multiple parameters", function () {
       expect(urls.get('discussion:detail', {'team_slug': 'loop', 'discussion_id': '3', 'slug': 'discussion'})).to.equal('loop/3/discussion/');
     });
-    it("can not get urls with wrong parameters", function () {
-      try {
-        var url = urls.get('discussion:detail', {'team': 'loop', 'discussion_id': '3', 'slug': 'discussion'});
-        expect(url).to.not.be.ok;
-      } catch (e) {
-        expect(e).to.be.instanceOf(Error);
-        expect(e.message).to.equal('Invalid parameter (team) for discussion:detail');
-      }
-    });
     it("can not get urls with missing parameters", function () {
       try {
         var url = urls.get('discussion:detail');

--- a/test/crossing.test.js
+++ b/test/crossing.test.js
@@ -113,7 +113,8 @@ describe("Crossing Tests", function() {
     var urls = new Crossing(new RegExp(':([a-zA-Z0-9-_%]{1,})', 'g'));
     var reactRouterPaths = {
       'discussion:detail': ':team_slug/:discussion_id/:slug/',
-      'search': 'search/'
+      'search': 'search/',
+      'team:detail': ':slug/',
     };
 
     it("can resolve urls with parameters", function () {
@@ -125,6 +126,14 @@ describe("Crossing Tests", function() {
       urls.load(reactRouterPaths);
       expect(urls.resolve('search/').name).to.equal('search');
       expect(Object.keys(urls.resolve('search/').kwargs).length).to.equal(0);
+    });
+
+    it("can get urls with one parameter", function () {
+      expect(urls.get('team:detail', {'slug': 'loop'})).to.equal('loop/');
+    });
+
+    it("can get urls with multiple parameters", function () {
+      expect(urls.get('discussion:detail', {'team_slug': 'loop', 'discussion_id': '3', 'slug': 'discussion'})).to.equal('loop/3/discussion/');
     });
   });
 


### PR DESCRIPTION
This opens Crossing to a wider range of regular expressions that can handle path parameters. It allows using kwargs with `react-router` as [demonstrated here](https://lincolnloop.com/blog/using-crossing-react-router/).
