### PR TITLE
Fix param's name detection in case of overrided param format

### DIFF
--- a/crossing.js
+++ b/crossing.js
@@ -17,14 +17,13 @@
 
     this._getArgs = function(urlName, path) {
       var args = {};
-      var nameMatches = this._urls[urlName].match(this._nameMatcher);
       var valueMatches = path.match(this._compiled[urlName]);
-      if (nameMatches) {
-        var i, len, arg;
-        for (i=0, len=nameMatches.length; i<len; i+=1) {
-          arg = nameMatches[i].substring(1, nameMatches[i].length-1);
-          args[arg] = valueMatches[i+1];;
-        }
+      var i=0;
+      var match = this._nameMatcher.exec(this._urls[urlName]);
+      while(match && match.length === 2 && valueMatches.length + 1 > i) {
+        var arg = match[1];
+        args[arg] = valueMatches[++i];
+        match = this._nameMatcher.exec(this._urls[urlName]);
       }
       return args;
     };

--- a/test/crossing.test.js
+++ b/test/crossing.test.js
@@ -98,8 +98,12 @@ describe("Crossing Tests", function() {
 
     it("can resolve urls with parameters", function () {
       urls.load(urlList);
-      expect(urls.resolve('loop/23/discussion-name/').name).to.equal('discussion:detail');
-      expect(Object.keys(urls.resolve('loop/23/discussion-name/').kwargs).length).to.equal(3);
+      var resolved = urls.resolve('loop/23/discussion-name/');
+      expect(resolved.name).to.equal('discussion:detail');
+      expect(Object.keys(resolved.kwargs).length).to.equal(3);
+      expect(resolved.kwargs.team_slug).to.equal('loop');
+      expect(resolved.kwargs.discussion_id).to.equal('23');
+      expect(resolved.kwargs.slug).to.equal('discussion-name');
     });
     it("can resolve urls without parameters", function () {
       urls.load(urlList);
@@ -119,8 +123,12 @@ describe("Crossing Tests", function() {
 
     it("can resolve urls with parameters", function () {
       urls.load(reactRouterPaths);
-      expect(urls.resolve('loop/23/discussion-name/').name).to.equal('discussion:detail');
-      expect(Object.keys(urls.resolve('loop/23/discussion-name/').kwargs).length).to.equal(3);
+      var resolved = urls.resolve('loop/23/discussion-name/');
+      expect(resolved.name).to.equal('discussion:detail');
+      expect(Object.keys(resolved.kwargs).length).to.equal(3);
+      expect(resolved.kwargs.team_slug).to.equal('loop');
+      expect(resolved.kwargs.discussion_id).to.equal('23');
+      expect(resolved.kwargs.slug).to.equal('discussion-name');
     });
     it("can resolve urls without parameters", function () {
       urls.load(reactRouterPaths);


### PR DESCRIPTION
Fix #5 

Use `RegExp.exec()` to get params' name in the `_getArgs` function to avoid loosing last param letter with some nameMatchers
