### PR TITLE
Remove sensibility to trailing slash in resolve method

### DIFF
--- a/crossing.js
+++ b/crossing.js
@@ -2,13 +2,14 @@
   'use strict';
   // Provides utilities to deal with website/app urls. Provides functionality
   // for deep-linking Ajax calls, and a url mapper to generate dynamic urls.
-  function crossing(nameMatcher) {
+  function crossing(nameMatcher, ignoreTrailingSlash) {
     if (!(this instanceof crossing)) {
       throw new Error('Crossing can not be called without instatiation. Please use "new Crossing()" instead');
     }
     this._urls = {};
     this._compiled = {};
     this._lastHash = '';
+    this._ignoreTrailingSlash = !!ignoreTrailingSlash;
     if (nameMatcher) {
       this._nameMatcher = nameMatcher;
     } else {
@@ -48,9 +49,11 @@
   // {'taskEdit': '/task/edit/<taskId>/', 'taskCreate': '/task/create/'}
   // @return {Object} this for method chaining
   crossing.prototype.load = function(urls) {
+    var endMatcher = this._ignoreTrailingSlash ? '/?$' : '$';
+
     for (var url in urls) {
       if (urls.hasOwnProperty(url)) {
-        this._compiled[url] = new RegExp('^' + urls[url].replace(this._nameMatcher, "([a-zA-Z0-9-_%]{0,})") + '$');
+        this._compiled[url] = new RegExp('^' + urls[url].replace(this._nameMatcher, "([a-zA-Z0-9-_%]{0,})") + endMatcher);
       }
     }
     this._urls = urls;

--- a/test/crossing.test.js
+++ b/test/crossing.test.js
@@ -145,4 +145,30 @@ describe("Crossing Tests", function() {
     });
   });
 
+  describe("#trailing slash", function () {
+    it('should be sensitive to trailing slash by default', function () {
+      var urls = new Crossing();
+      urls.load({
+        'discussion:detail': '<team_slug>/<discussion_id>/<slug>/',
+        'search': 'search'
+      });
+      expect(urls.resolve('loop/23/discussion-name')).to.equal(undefined);
+      expect(urls.resolve('loop/23/discussion-name/').name).to.equal('discussion:detail');
+      expect(urls.resolve('search').name).to.equal('search');
+      expect(urls.resolve('search/')).to.equal(undefined);
+    });
+
+    it('should resolve url with or without trailing slash if ignoreTrailingSlash param is true', function () {
+      var urls = new Crossing(null, true);
+      urls.load({
+        'discussion:detail': '<team_slug>/<discussion_id>/<slug>',
+        'search': 'search'
+      });
+      expect(urls.resolve('loop/23/discussion-name').name).to.equal('discussion:detail');
+      expect(urls.resolve('loop/23/discussion-name/').name).to.equal('discussion:detail');
+      expect(urls.resolve('search').name).to.equal('search');
+      expect(urls.resolve('search/').name).to.equal('search');
+    });
+  });
+
 });


### PR DESCRIPTION
By default, resolve method is not sensitive to trailing slash.
Strict matching can be forced trough the second param of the constructor.

close #7 
