### PR TITLE
fix(crossing): undefined args

### DIFF
--- a/crossing.js
+++ b/crossing.js
@@ -66,16 +66,17 @@
 
     if (kwargs) {
       var args = path.match(matcher);
-
-      for (var i = 0; i < args.length; i++) {
-        var match = args[i];
-        var arg = match.replace(matcher, '$1');
-
-        if (typeof kwargs[arg] === 'undefined') {
-          throw new Error('Missing parameter (' + arg + ') for ' + name);
+      if (args) {
+        for (var i = 0; i < args.length; i++) {
+          var match = args[i];
+          var arg = match.replace(matcher, '$1');
+  
+          if (typeof kwargs[arg] === 'undefined') {
+            throw new Error('Missing parameter (' + arg + ') for ' + name);
+          }
+  
+          path = path.replace(match, kwargs[arg]);
         }
-
-        path = path.replace(match, kwargs[arg]);
       }
     }
 

--- a/test/crossing.test.js
+++ b/test/crossing.test.js
@@ -50,6 +50,10 @@ describe("Crossing Tests", function() {
       urls.load(urlList);
       expect(urls.get('search')).to.equal('search/');
     });
+    it("can get urls with void kwargs", function () {
+      urls.load(urlList);
+      expect(urls.get('search',{})).to.equal('search/');
+    });
     it("can get urls with one parameter", function () {
       expect(urls.get('team:detail', {'slug': 'loop'})).to.equal('loop/');
     });


### PR DESCRIPTION
 Allow use of kwargs object with static routes (without slug). Usefull for routing automization
